### PR TITLE
Issue 7b

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -6,6 +6,11 @@ class Book < ApplicationRecord
   has_many :favorites
   has_many :book_comments
 
+  scope :created_today, -> { where(created_at: Time.zone.now.all_day) } #今日
+  scope :created_yesterday, -> { where(created_at: 1.day.ago.all_day) } #前日
+  scope :created_this_week, -> { where(created_at: 6.day.ago.beginning_of_day..Time.zone.now.end_of_day )} #今週
+  scope :created_last_week, -> { where(created_at: 2.week.ago.beginning_of_day..1.week.ago.end_of_day)}#先週
+
   def favorited_by?(user)
     favorites.where(user_id: user.id).exists?
   end

--- a/app/views/users/_post_number.html.erb
+++ b/app/views/users/_post_number.html.erb
@@ -1,0 +1,40 @@
+<h2>投稿数の前日比・前週比</h2>
+<table class = "table table-bordered">
+ <tr>
+  <th>今日の投稿数</th>
+  <th>前日の投稿数</th>
+  <th>前日比</th>
+ </tr>
+ <tr>
+  <td><%= user.books.created_today.count %></td>
+  <td><%= user.books.created_yesterday.count %></td>
+  
+  <td>
+   <% if user.books.created_yesterday.count == 0 %>
+   前日の投稿はありません
+   <% else %>
+  <%= user.books.created_today.count.to_i / user.books.created_yesterday.count.to_i*100.round %> %
+   <% end %>
+  </td> 
+ </tr>
+</table>
+<table class = "table table-bordered"> 
+ <tr>
+  <th>今週の投稿数</th>
+  <th>全集の投稿数</th>
+  <th>前週比</th>
+ </tr>
+ <tr>
+  <td><%= user.books.created_this_week.count %></td>
+  <td><%= user.books.created_last_week.count %></td>
+  <td>
+   <% if user.books.created_last_week.count == 0 %>
+   前日の投稿はありません
+   <% else %>
+  <%= user.books.created_this_week.count.to_i / user.books.created_last_week.count.to_i*100.round %> %
+   <% end %>
+
+  
+  </td> 
+ <tr>
+</table>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,5 +13,6 @@
     <h2>Books</h2>
 
     <%= render 'books/index',books: @books %>
+    <%= render 'post_number', user: @user %>
   </div>
 </div>

--- a/db/migrate/20210929091033_create_user_rooms.rb
+++ b/db/migrate/20210929091033_create_user_rooms.rb
@@ -5,6 +5,7 @@ class CreateUserRooms < ActiveRecord::Migration[5.2]
       t.integer :room_id
 
       t.timestamps
+      
     end
   end
 end


### PR DESCRIPTION

ユーザ詳細ページに、今日の投稿数を表示させる
--
  | ユーザ詳細ページに、前日の投稿数を表示させる
  | ユーザ詳細ページに、前日と今日の投稿数の差を表示させる(今日の数値 / その前日の数値)
  | ユーザ詳細ページに、今週の投稿数の合計を表示させる例：本日 →2021/05/21（金）の場合　　 2021/05/15（土） ~ 2021/05/21（金）が今週と解釈
  | ユーザ詳細ページに、先週の投稿数の合計を表示させる例：本日 →2021/05/21（金）の場合　　 2021/05/08（土）~ 2021/05/14（金）が前週と解釈
  | ユーザ詳細ページに、今週と先週の投稿数の差を表示させる(先週と比べる)

